### PR TITLE
Ignore `init.jl` files in code coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+- "**/init.jl"


### PR DESCRIPTION
The methods in the initialization files do not get called if the BC data files are loaded from a cache, which results in artificially low coverage statistics.