### PR TITLE
Update MIST URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A bolometric correction (BC) is the offset between a star's absolute bolometric magnitude and its absolute magnitude in a specific bandpass or filter (e.g., V band). In order to place theoretical stellar models into observational filter spaces, bolometric corrections must be applied to the bolometric magnitudes of the stellar models. Here we provide access to and interpolation of pre-computed grids of [bolometric corrections](https://en.wikipedia.org/wiki/Bolometric_correction). See our documentation linked in the badges above for additional information. Currently supported bolometric correction grids are
 
- - [MIST](https://waps.cfa.harvard.edu/MIST/)
+ - [MIST](https://mist.science)
  - [YBC](https://gitlab.com/parsec-group/public_repos/YBC_tables), which interpolates between several different BC libaries -- supported sub-libraries are
    - [PHOENIX](https://svo2.cab.inta-csic.es/theory/newov2/index.php?models=bt-settl-agss)
    - [ATLAS9](https://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/castelli-and-kurucz-atlas)

--- a/docs/src/MIST.md
+++ b/docs/src/MIST.md
@@ -1,6 +1,6 @@
 # [MIST](@id MIST)
 
-This submodule enables interaction with the bolometric correction (BC) grid released as part of the Mesa Isochrones & Stellar Tracks ([MIST](https://waps.cfa.harvard.edu/MIST/) [Dotter2016,Choi2016](@cite)) project. The MIST BC grid is convenient because it includes a wide range of photometric filters and covers the full range of effective temperature, surface gravity, and metallicity relevant for most applications in stellar evolution. The grid is also *regular* in the dependent variables, greatly simplifying interpolation. The following figure shows a projection of a small portion of the BC table for one choice of metallicity and V-band extinction.
+This submodule enables interaction with the bolometric correction (BC) grid released as part of the Mesa Isochrones & Stellar Tracks ([MIST](https://mist.science) [Dotter2016,Choi2016](@cite)) project. The MIST BC grid is convenient because it includes a wide range of photometric filters and covers the full range of effective temperature, surface gravity, and metallicity relevant for most applications in stellar evolution. The grid is also *regular* in the dependent variables, greatly simplifying interpolation. The following figure shows a projection of a small portion of the BC table for one choice of metallicity and V-band extinction.
 
 ```@example
 using BolometricCorrections # hide

--- a/src/MIST/init.jl
+++ b/src/MIST/init.jl
@@ -109,105 +109,105 @@ const BC_sets = ("CFHT_MegaCam", "DECam", "GALEX", "HST_ACS_HRC", "HST_ACS_WFC",
                  "WFIRST", "WISE")
 
 function __init__()
-    prefix = "https://waps.cfa.harvard.edu/MIST/BC_tables/"
+    v1_prefix = "https://mist.science/BC_tables/v1/"
     # Actually just distribute zeropoints with source
     # register(DataDep("MIST_zeropoints", "Zeropoint conversion table for MIST BCs",
-    #                  prefix*"zeropoints.txt"))
+    #                  v1_prefix*"zeropoints.txt"))
     # datadep"MIST_zeropoints" # We always want to download these
     register(DataDep("MIST_CFHT_MegaCam", "MIST bolometric corrections for CFHT/MegaCam",
-                     prefix*"CFHTugriz.txz",
+                     v1_prefix*"CFHTugriz.txz",
                      "cf10e060b65591cb43fc55544260a75ec559c28d9454a4f681a197af26aa0fcd";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_DECam", "MIST bolometric corrections for the Dark Energy Camera (DECam)",
-                     prefix*"DECam.txz",
+                     v1_prefix*"DECam.txz",
                      "6da654fed0e5bcf26fb196411e94c4c8b4306abc05f1dfddfab697848c3d41a7";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_GALEX", "MIST bolometric corrections for GALEX",
-                     prefix*"GALEX.txz",
+                     v1_prefix*"GALEX.txz",
                      "c390b58e3d1d15fd6c276ead3d08030ee12b36d03b7413296bb9a1caeda48766";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_HST_ACS_HRC", "MIST bolometric corrections for HST ACS High-Resolution Channel",
-                     prefix*"HST_ACSHR.txz",
+                     v1_prefix*"HST_ACSHR.txz",
                      "065e5235a55b24541a027000f358a08036e7305fb105865497e8e8c452fa512d";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_HST_ACS_WFC", "MIST bolometric corrections for HST ACS Wide Field Channel",
-                     prefix*"HST_ACSWF.txz",
+                     v1_prefix*"HST_ACSWF.txz",
                      "5e48f529d245dae122f3ac86c6524f34cf6b0952816cd4a567d78c41e3439571";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_HST_WFC3", "MIST bolometric corrections for HST WFC3",
-                     prefix*"HST_WFC3.txz",
+                     v1_prefix*"HST_WFC3.txz",
                      "39fdf9a2606b6f66f5388c2a02bdb18bb1c32402325484c917b5cd564bcd124d";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_HST_WFPC2", "MIST bolometric corrections for HST WFPC2",
-                     prefix*"HST_WFPC2.txz",
+                     v1_prefix*"HST_WFPC2.txz",
                      "941f18684c741979d53a6b4a4083a8cd913a6fbefe03c5bfc5ee179590d14410";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_JWST", "MIST bolometric corrections for the James Webb Space Telescope (JWST, pre-launch, added 02/15/2017)",
-                     prefix*"JWST.txz",
+                     v1_prefix*"JWST.txz",
                      "580d13c2dfe6086f8593828170f573fd653f6a51051d0437b602034cb5b49779";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_LSST", "MIST bolometric corrections for the Vera Rubin Observatory which will conduct the Legacy Survey of Space and Time (LSST, added 02/15/2017)",
-                     prefix*"LSST.txz",
+                     v1_prefix*"LSST.txz",
                      "6546d0e444a5c363a8649f5f5515b1f569161ae79c1d21ef2525aa169c57791e";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_PanSTARRS", "MIST bolometric corrections for PanSTARRS",
-                     prefix*"PanSTARRS.txz",
+                     v1_prefix*"PanSTARRS.txz",
                      "f841169b5dacb8063111795212b6e84a4977fbaeb5cc1e6afc9f4e3579e89a15";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_SDSS", "MIST bolometric corrections for the Sloan Digital Sky Survey (SDSS)",
-                     prefix*"SDSSugriz.txz",
+                     v1_prefix*"SDSSugriz.txz",
                      "f2d6eb565f851ee52a45530a498817470c3567c7af245fb4228f5d65ee3f7d78";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_SkyMapper", "MIST bolometric corrections for SkyMapper",
-                     prefix*"SkyMapper.txz",
+                     v1_prefix*"SkyMapper.txz",
                      "7e54b341235d9e0ab824c6c77a22348f0c194a997d28faf26c910e9996b35de2";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_HSC", "MIST bolometric corrections for Subaru Hyper Suprime-Cam (added 01/29/2019)",
-                     prefix*"HSC.txz",
+                     v1_prefix*"HSC.txz",
                      "5682c9bc306a871961b836a9a95cb7c934de254bf86678d2b6b0f9ec4fac37fe";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_IPHAS", "MIST bolometric corrections for the INT Photometric H-α Survey (IPHAS)",
-                     prefix*"IPHAS.txz",
+                     v1_prefix*"IPHAS.txz",
                      "f3f9f1d9cb21ea9e6d503df0e56c528bf30c3c32a0ea82f9c96580012685be9d";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_Spitzer", "MIST bolometric corrections for the Spitzer IRAC",
-                     prefix*"SPITZER.txz",
+                     v1_prefix*"SPITZER.txz",
                      "a65a25d256fe77db5400ce0acd10f70ffd80b2ece70344bbc9b6af0bea0188cb";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_SPLUS", "MIST bolometric corrections for the S-PLUS survey (added 12/27/2020)",
-                     prefix*"SPLUS.txz",
+                     v1_prefix*"SPLUS.txz",
                      "9da093595b0c2c87c3b1fa7cb4dec418059f0e24520c3534a79ef586357c6cdf";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_Swift", "MIST bolometric corrections for the Swift Observatory",
-                     prefix*"Swift.txz",
+                     v1_prefix*"Swift.txz",
                      "be5db86e0f92b2329278202703962b28dfe9134b251408bc4bea48719d2a0b40";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_UBVRIplus", "MIST bolometric corrections for the Bessell filters, 2MASS, Kepler, Hipparcos, Gaia (DR2/MAW/EDR3), Tycho, and Tess",
-                     prefix*"UBVRIplus.txz",
+                     v1_prefix*"UBVRIplus.txz",
                      "524dc5d0fe7c9993ce9d07d32063fda8ce3dad09139739fff14868e89ae622c4";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_UKIDSS", "MIST bolometric corrections for the UKIDSS survey",
-                     prefix*"UKIDSS.txz",
+                     v1_prefix*"UKIDSS.txz",
                      "995464124c4b347eaaf164baf8a9a43213ae55c75dd9bd9d0b400632fa71a578";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_UVIT", "MIST bolometric corrections for the Ultra-Violet Imaging Telescope (UVIT)",
-                     prefix*"UVIT.txz",
+                     v1_prefix*"UVIT.txz",
                      "f9cba3a8636d8221c639bb894bf27c7defc66eb9e72ec33533bec1fc4480c559";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_VISTA", "MIST bolometric corrections for the Visible and Infrared Survey Telescope for Astronomy (VISTA)",
-                     prefix*"VISTA.txz",
+                     v1_prefix*"VISTA.txz",
                      "3895d64e3958739db7ba7afd45d17947094d583cd86a5aa382513cc444744d8a";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_Washington", "MIST bolometric corrections for Washington, Strömgren, and DDO51 filters",
-                     prefix*"WashDDOuvby.txz",
+                     v1_prefix*"WashDDOuvby.txz",
                      "1c0e783020c7496c31deec5313e31f0af50e7b4452da9a1062d1e4401c16925d";
                      post_fetch_method=custom_unpack))
     register(DataDep("MIST_WFIRST", "MIST bolometric corrections for the Nancy Grace Roman Telescope (formerly WFIRST)",
-                     prefix*"WFIRST.txz",
+                     v1_prefix*"WFIRST.txz",
                      "b8830f926858426fcfa3cc47a101911a48806daabd64817d68788a94a33f6df6";
                      post_fetch_method=custom_unpack))    
     register(DataDep("MIST_WISE", "MIST bolometric corrections for the Wide-field Infrared Explorer (WISE)",
-                     prefix*"WISE.txz",
+                     v1_prefix*"WISE.txz",
                      "c4d6dc726fca9e0d228e660a70bf4e96b9e8c2e4abde99673621a5ef3aa75dff";
                      post_fetch_method=custom_unpack))
     # Load datadeps for development

--- a/src/MIST/init.jl
+++ b/src/MIST/init.jl
@@ -100,7 +100,7 @@ end
 
 
 
-# See https://waps.cfa.harvard.edu/MIST/model_grids.html#bolometric 
+# See https://mist.science/model_grids.html
 "Available filter sets for MIST bolometric corrections."
 const BC_sets = ("CFHT_MegaCam", "DECam", "GALEX", "HST_ACS_HRC", "HST_ACS_WFC",
                  "HST_WFC3", "HST_WFPC2", "JWST", "LSST", "PanStARRS", "SDSS",


### PR DESCRIPTION
Closes #27.

The MIST data have moved to a new url: https://mist.science

This PR updates the necessary references to use the new url